### PR TITLE
feat: 오늘의 질문, 답변, ai 피드백, 댓글 등 api 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.5",
     "@tailwindcss/vite": "^4.1.16",
+    "axios": "^1.13.2",
     "dompurify": "^3.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.16
         version: 4.1.16(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2))
+      axios:
+        specifier: ^1.13.2
+        version: 1.13.2
       dompurify:
         specifier: ^3.3.0
         version: 3.3.0
@@ -889,6 +892,12 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -905,6 +914,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -924,6 +937,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -958,6 +975,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -968,12 +989,32 @@ packages:
   dompurify@3.3.0:
     resolution: {integrity: sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1084,6 +1125,19 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1091,6 +1145,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1108,6 +1170,10 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1117,6 +1183,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1285,6 +1359,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1292,6 +1370,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1371,6 +1457,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2306,6 +2395,16 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  axios@1.13.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.28.4
@@ -2327,6 +2426,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   chalk@4.1.2:
@@ -2341,6 +2445,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
 
@@ -2370,6 +2478,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   dom-helpers@5.2.1:
@@ -2381,6 +2491,12 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
@@ -2389,6 +2505,21 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2541,10 +2672,38 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -2558,11 +2717,19 @@ snapshots:
 
   globals@16.5.0: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -2691,12 +2858,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@3.1.2:
     dependencies:
@@ -2769,6 +2944,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,50 +1,19 @@
-export interface KakaoLoginResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  data: {
-    accessToken: string;
-    refreshToken: string;
-    isNewUser: boolean;
-    hasFamily: boolean;
-  };
-  success: boolean;
-}
+import apiClient from "./axios";
+import type { ApiResponse } from "./axios";
+
+export interface KakaoLoginResponse extends ApiResponse<{
+  accessToken: string;
+  refreshToken: string;
+  isNewUser: boolean;
+  hasFamily: boolean;
+}> {}
 
 export const kakaoLoginApi = async (
   authorizationCode: string
 ): Promise<KakaoLoginResponse> => {
-  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
-  const url = `${API_BASE_URL}/api/auth/kakao/login`;
-
-  const requestBody = {
-    authorizationCode: authorizationCode,
-  };
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(requestBody),
+  const response = await apiClient.post<KakaoLoginResponse>("/api/auth/kakao/login", {
+    authorizationCode,
   });
-
-  const responseText = await response.text();
-
-  let data: KakaoLoginResponse;
-  try {
-    data = JSON.parse(responseText);
-  } catch (parseError) {
-    throw new Error(responseText || `HTTP error! status: ${response.status}`);
-  }
-
-  if (!response.ok || !data.isSuccess) {
-    const error = new Error(data.message || `HTTP error! status: ${response.status}`);
-    (error as any).response = data;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return data;
+  return response.data;
 };
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,65 @@
+import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from "axios";
+import { getAccessToken } from "../utils/token";
+
+// 공통 API 응답 타입
+export interface ApiResponse<T = any> {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  data: T;
+  success: boolean;
+}
+
+// axios 인스턴스 생성
+const apiClient: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:8080",
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// Request Interceptor: 토큰 자동 추가
+apiClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const accessToken = getAccessToken();
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// Response Interceptor: 에러 처리 통일
+apiClient.interceptors.response.use(
+  (response) => {
+    // 응답이 성공적이지만 isSuccess가 false인 경우
+    const data = response.data as ApiResponse;
+    if (data && typeof data === "object" && "isSuccess" in data && !data.isSuccess) {
+      const error = new Error(data.message || "API 요청이 실패했습니다.");
+      (error as any).response = data;
+      (error as any).status = response.status;
+      return Promise.reject(error);
+    }
+    return response;
+  },
+  (error: AxiosError) => {
+    // 네트워크 에러 또는 기타 에러 처리
+    if (error.response) {
+      // 서버에서 응답을 받았지만 에러 상태 코드
+      const data = error.response.data as ApiResponse;
+      if (data && typeof data === "object" && "message" in data) {
+        const apiError = new Error(data.message || `HTTP error! status: ${error.response.status}`);
+        (apiError as any).response = data;
+        (apiError as any).status = error.response.status;
+        return Promise.reject(apiError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;
+

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,69 @@
+import apiClient from "./axios";
+import type { ApiResponse } from "./axios";
+
+export interface CommentItem {
+  commentId: number;
+  dailyQuestionId: number;
+  userId: number;
+  userNickname: string;
+  content: string;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommentsResponse extends ApiResponse<CommentItem[]> {}
+
+export const getComments = async (
+  dailyQuestionId: number
+): Promise<CommentsResponse> => {
+  const response = await apiClient.get<CommentsResponse>("/api/comments", {
+    params: { dailyQuestionId },
+  });
+  return response.data;
+};
+
+export interface CreateCommentRequest {
+  dailyQuestionId: number;
+  content: string;
+  type: "TEXT" | "EMOJI" | "BOTH";
+}
+
+export interface CreateCommentResponse extends ApiResponse<CommentItem> {}
+
+export const createComment = async (
+  request: CreateCommentRequest
+): Promise<CreateCommentResponse> => {
+  const response = await apiClient.post<CreateCommentResponse>("/api/comments", request);
+  return response.data;
+};
+
+export interface UpdateCommentRequest {
+  content: string;
+  type: "TEXT" | "EMOJI" | "BOTH";
+}
+
+export interface UpdateCommentResponse extends ApiResponse<CommentItem> {}
+
+export const updateComment = async (
+  commentId: number,
+  request: UpdateCommentRequest
+): Promise<UpdateCommentResponse> => {
+  const response = await apiClient.put<UpdateCommentResponse>(
+    `/api/comments/${commentId}`,
+    request
+  );
+  return response.data;
+};
+
+export interface DeleteCommentResponse extends ApiResponse<string> {}
+
+export const deleteComment = async (
+  commentId: number
+): Promise<DeleteCommentResponse> => {
+  const response = await apiClient.delete<DeleteCommentResponse>(
+    `/api/comments/${commentId}`
+  );
+  return response.data;
+};
+

--- a/src/api/daily-question.ts
+++ b/src/api/daily-question.ts
@@ -1,0 +1,87 @@
+import apiClient from "./axios";
+import type { ApiResponse } from "./axios";
+
+export interface QuestionMember {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+  answered: boolean;
+  answerContent?: string;
+}
+
+export interface TodayQuestionResponse extends ApiResponse<{
+  dailyQuestionId: number;
+  questionId: number;
+  questionNumber: number;
+  questionText: string;
+  counselingTechnique: string;
+  description: string;
+  exampleAnswer: string;
+  isAllAnswered: boolean;
+  assignedDate: string;
+  members: QuestionMember[];
+}> {}
+
+export interface FamilyAnswer {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface FamilyAnswersResponse extends ApiResponse<FamilyAnswer[]> {}
+
+export const getTodayQuestion = async (): Promise<TodayQuestionResponse> => {
+  const response = await apiClient.get<TodayQuestionResponse>("/api/daily-questions/today");
+  return response.data;
+};
+
+export const getFamilyAnswers = async (
+  dailyQuestionId: number
+): Promise<FamilyAnswersResponse> => {
+  const response = await apiClient.get<FamilyAnswersResponse>(
+    `/api/daily-questions/${dailyQuestionId}/answers`
+  );
+  return response.data;
+};
+
+export interface DraftAnswerRequest {
+  content: string;
+}
+
+export interface DraftAnswerResponse extends ApiResponse<{
+  originalAnswer: string;
+  improvedAnswer: string;
+  emotion: string;
+  feedback: string[];
+}> {}
+
+export const createDraftAnswer = async (
+  dailyQuestionId: number,
+  content: string
+): Promise<DraftAnswerResponse> => {
+  const response = await apiClient.post<DraftAnswerResponse>(
+    `/api/daily-questions/${dailyQuestionId}/answers/draft`,
+    { content: content.trim() }
+  );
+  return response.data;
+};
+
+export interface SubmitFinalAnswerRequest {
+  finalContent: string;
+}
+
+export interface SubmitFinalAnswerResponse extends ApiResponse<string> {}
+
+export const submitFinalAnswer = async (
+  dailyQuestionId: number,
+  finalContent: string
+): Promise<SubmitFinalAnswerResponse> => {
+  const response = await apiClient.patch<SubmitFinalAnswerResponse>(
+    `/api/daily-questions/${dailyQuestionId}/answers`,
+    { finalContent: finalContent.trim() }
+  );
+  return response.data;
+};
+

--- a/src/api/family.ts
+++ b/src/api/family.ts
@@ -1,4 +1,5 @@
-import { getAccessToken } from "../utils/token";
+import apiClient from "./axios";
+import type { ApiResponse } from "./axios";
 
 export interface FamilyMember {
   userId: number;
@@ -6,181 +7,63 @@ export interface FamilyMember {
   profileImageUrl: string;
 }
 
-export interface FamilySearchResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  data: {
-    familyId: number;
-    familyName: string;
-    inviteCode: string;
-    memberCount: number;
-    members: FamilyMember[];
-  };
-  success: boolean;
-}
+export interface FamilySearchResponse extends ApiResponse<{
+  familyId: number;
+  familyName: string;
+  inviteCode: string;
+  memberCount: number;
+  members: FamilyMember[];
+}> {}
 
 export interface FamilyCreateRequest {
   familyName: string;
 }
 
-export interface FamilyCreateResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  data: {
-    familyId: number;
-    familyName: string;
-    inviteCode: string;
-    createdBy: number;
-    createdAt: string;
-  };
-  success: boolean;
-}
+export interface FamilyCreateResponse extends ApiResponse<{
+  familyId: number;
+  familyName: string;
+  inviteCode: string;
+  createdBy: number;
+  createdAt: string;
+}> {}
 
 export const searchFamilyByInviteCode = async (
   inviteCode: string
 ): Promise<FamilySearchResponse> => {
-  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
-  const url = `${API_BASE_URL}/api/families/search?invite-code=${encodeURIComponent(inviteCode)}`;
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
-  const accessToken = getAccessToken();
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const response = await fetch(url, {
-    method: "GET",
-    headers,
+  const response = await apiClient.get<FamilySearchResponse>("/api/families/search", {
+    params: { "invite-code": inviteCode },
   });
-
-  const responseText = await response.text();
-
-  let data: FamilySearchResponse;
-  try {
-    data = JSON.parse(responseText);
-  } catch (parseError) {
-    throw new Error(responseText || `HTTP error! status: ${response.status}`);
-  }
-
-  if (!response.ok || !data.isSuccess) {
-    const error = new Error(data.message || `HTTP error! status: ${response.status}`);
-    (error as any).response = data;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return data;
+  return response.data;
 };
 
 export const createFamily = async (
   familyName: string
 ): Promise<FamilyCreateResponse> => {
-  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
-  const url = `${API_BASE_URL}/api/families`;
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
-  const accessToken = getAccessToken();
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const requestBody: FamilyCreateRequest = {
+  const response = await apiClient.post<FamilyCreateResponse>("/api/families", {
     familyName: familyName.trim(),
-  };
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(requestBody),
   });
-
-  const responseText = await response.text();
-
-  let data: FamilyCreateResponse;
-  try {
-    data = JSON.parse(responseText);
-  } catch (parseError) {
-    throw new Error(responseText || `HTTP error! status: ${response.status}`);
-  }
-
-  if (!response.ok || !data.isSuccess) {
-    const error = new Error(data.message || `HTTP error! status: ${response.status}`);
-    (error as any).response = data;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return data;
+  return response.data;
 };
 
 export interface JoinFamilyRequest {
   inviteCode: string;
 }
 
-export interface JoinFamilyResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  data: {
-    familyId: number;
-    familyName: string;
-    inviteCode: string;
-    memberId: number;
-    role: string;
-    joinedAt: string;
-  };
-  success: boolean;
-}
+export interface JoinFamilyResponse extends ApiResponse<{
+  familyId: number;
+  familyName: string;
+  inviteCode: string;
+  memberId: number;
+  role: string;
+  joinedAt: string;
+}> {}
 
 export const joinFamily = async (
   inviteCode: string
 ): Promise<JoinFamilyResponse> => {
-  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
-  const url = `${API_BASE_URL}/api/families/join`;
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
-  const accessToken = getAccessToken();
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const requestBody: JoinFamilyRequest = {
-    inviteCode: inviteCode,
-  };
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(requestBody),
+  const response = await apiClient.post<JoinFamilyResponse>("/api/families/join", {
+    inviteCode,
   });
-
-  const responseText = await response.text();
-
-  let data: JoinFamilyResponse;
-  try {
-    data = JSON.parse(responseText);
-  } catch (parseError) {
-    throw new Error(responseText || `HTTP error! status: ${response.status}`);
-  }
-
-  if (!response.ok || !data.isSuccess) {
-    const error = new Error(data.message || `HTTP error! status: ${response.status}`);
-    (error as any).response = data;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return data;
+  return response.data;
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,60 +1,22 @@
-import { getAccessToken } from "../utils/token";
+import apiClient from "./axios";
+import type { ApiResponse } from "./axios";
 
 export interface UpdateProfileRequest {
   nickname?: string;
   profileImageUrl?: string;
 }
 
-export interface UpdateProfileResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  data: {
-    userId: number;
-    nickname: string;
-    profileImageUrl: string;
-    updatedAt: string;
-  };
-  success: boolean;
-}
+export interface UpdateProfileResponse extends ApiResponse<{
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+  updatedAt: string;
+}> {}
 
 export const updateProfile = async (
   request: UpdateProfileRequest
 ): Promise<UpdateProfileResponse> => {
-  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
-  const url = `${API_BASE_URL}/api/users/profile`;
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
-  const accessToken = getAccessToken();
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const response = await fetch(url, {
-    method: "PATCH",
-    headers,
-    body: JSON.stringify(request),
-  });
-
-  const responseText = await response.text();
-
-  let data: UpdateProfileResponse;
-  try {
-    data = JSON.parse(responseText);
-  } catch (parseError) {
-    throw new Error(responseText || `HTTP error! status: ${response.status}`);
-  }
-
-  if (!response.ok || !data.isSuccess) {
-    const error = new Error(data.message || `HTTP error! status: ${response.status}`);
-    (error as any).response = data;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return data;
+  const response = await apiClient.patch<UpdateProfileResponse>("/api/users/profile", request);
+  return response.data;
 };
 

--- a/src/components/daily-question/CommentBottomSheet.tsx
+++ b/src/components/daily-question/CommentBottomSheet.tsx
@@ -1,0 +1,159 @@
+import CommentItem from "./CommentItem";
+import CommentInput from "./CommentInput";
+import EmojiSelector from "./EmojiSelector";
+
+interface Comment {
+  id: number;
+  userName: string;
+  timeAgo: string;
+  emoji?: string;
+  content: string;
+  hasContent: boolean;
+}
+
+interface Emoji {
+  id: string;
+  label: string;
+  src: string;
+}
+
+interface CommentBottomSheetProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  comments: Comment[];
+  commentText: string;
+  selectedEmoji: Emoji | null;
+  isEmojiOpen: boolean;
+  emojiList: Emoji[];
+  openMenuId: number | null;
+  editingCommentId: number | null;
+  editingCommentText: string;
+  editingSelectedEmoji: Emoji | null;
+  currentUserId: number | null;
+  getEmojiById: (emojiId?: string) => Emoji | null;
+  onClose: () => void;
+  onCommentTextChange: (text: string) => void;
+  onEmojiToggle: () => void;
+  onEmojiSelect: (emoji: Emoji) => void;
+  onRemoveEmoji: () => void;
+  onSend: () => void;
+  onMoreClick: (commentId: number, e: React.MouseEvent) => void;
+  onEdit: (commentId: number) => void;
+  onDelete: (commentId: number) => void;
+  onEditingCommentTextChange: (text: string) => void;
+  onEditingEmojiSelect: (emoji: Emoji) => void;
+  onEditingRemoveEmoji: () => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+}
+
+const CommentBottomSheet = ({
+  isOpen,
+  isLoading,
+  comments,
+  commentText,
+  selectedEmoji,
+  isEmojiOpen,
+  emojiList,
+  openMenuId,
+  editingCommentId,
+  editingCommentText,
+  editingSelectedEmoji,
+  currentUserId,
+  getEmojiById,
+  onClose,
+  onCommentTextChange,
+  onEmojiToggle,
+  onEmojiSelect,
+  onRemoveEmoji,
+  onSend,
+  onMoreClick,
+  onEdit,
+  onDelete,
+  onEditingCommentTextChange,
+  onEditingEmojiSelect,
+  onEditingRemoveEmoji,
+  onSaveEdit,
+  onCancelEdit,
+}: CommentBottomSheetProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* 배경 오버레이 */}
+      <div
+        className="fixed inset-0 bg-black/32 z-[998]"
+        onClick={onClose}
+      />
+
+      {/* 바텀 시트 */}
+      <div className="fixed bottom-0 left-0 right-0 w-full max-w-[420px] mx-auto bg-white rounded-t-[16px] shadow-[0_-4px_8px_rgba(0,0,0,0.08)] z-[999] flex flex-col max-h-[90vh]">
+        {/* 헤더 */}
+        <div className="flex flex-row items-center justify-center h-[57px] px-5 border-b border-[#EAEAEA]">
+          <div className="label-bold text-text">댓글</div>
+        </div>
+
+        {/* 댓글 리스트 */}
+        <div className="flex-1 overflow-y-auto pt-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="body text-sub-text">댓글을 불러오는 중...</div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-y-4">
+              {comments.map((comment, index) => {
+                const commentEmoji = getEmojiById(comment.emoji);
+                return (
+                  <CommentItem
+                    key={comment.id}
+                    comment={comment}
+                    emoji={commentEmoji}
+                    isLast={index === comments.length - 1}
+                    openMenuId={openMenuId}
+                    isEditing={editingCommentId === comment.id}
+                    editingText={editingCommentText}
+                    editingSelectedEmoji={editingSelectedEmoji}
+                    emojiList={emojiList}
+                    currentUserId={currentUserId}
+                    onMoreClick={onMoreClick}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                    onEditingTextChange={onEditingCommentTextChange}
+                    onEditingEmojiSelect={onEditingEmojiSelect}
+                    onEditingRemoveEmoji={onEditingRemoveEmoji}
+                    onSaveEdit={onSaveEdit}
+                    onCancelEdit={onCancelEdit}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* 댓글 입력 필드 */}
+        <CommentInput
+          commentText={commentText}
+          selectedEmoji={selectedEmoji}
+          isEmojiOpen={isEmojiOpen}
+          onCommentTextChange={onCommentTextChange}
+          onEmojiToggle={onEmojiToggle}
+          onEmojiSelect={onEmojiSelect}
+          onRemoveEmoji={onRemoveEmoji}
+          onSend={onSend}
+        />
+
+        {/* 이모지 선택 그리드 */}
+        {isEmojiOpen && (
+          <div className="px-5 max-px-[20px] border-t border-[#EAEAEA] bg-outline">
+            <div className="flex flex-col">
+              <EmojiSelector emojiList={emojiList} onSelect={onEmojiSelect} />
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default CommentBottomSheet;
+

--- a/src/components/daily-question/CommentInput.tsx
+++ b/src/components/daily-question/CommentInput.tsx
@@ -1,0 +1,112 @@
+import emoji from "../../../public/icon/emoji.svg";
+import emojiOn from "../../../public/icon/emojiOn.svg";
+import send from "../../../public/icon/send.svg";
+import X from "../../../public/icon/X.svg";
+
+interface Emoji {
+  id: string;
+  label: string;
+  src: string;
+}
+
+interface CommentInputProps {
+  commentText: string;
+  selectedEmoji: Emoji | null;
+  isEmojiOpen: boolean;
+  onCommentTextChange: (text: string) => void;
+  onEmojiToggle: () => void;
+  onEmojiSelect: (emoji: Emoji) => void;
+  onRemoveEmoji: () => void;
+  onSend: () => void;
+}
+
+const CommentInput = ({
+  commentText,
+  selectedEmoji,
+  isEmojiOpen,
+  onCommentTextChange,
+  onEmojiToggle,
+  onEmojiSelect,
+  onRemoveEmoji,
+  onSend,
+}: CommentInputProps) => {
+  return (
+    <div
+      className="px-5 max-px-[20px] pt-[12px] border-t border-[#EAEAEA]"
+      style={{ boxShadow: "0px -4px 8px 0px #00000014" }}
+    >
+      <div className="flex flex-col">
+        {/* 입력 영역 */}
+        <div className="flex flex-row items-start gap-[10px] mb-[12px]">
+          {/* 이모지 버튼 */}
+          <button
+            onClick={onEmojiToggle}
+            className="w-[24px] h-[24px] flex items-center justify-center flex-shrink-0 my-auto focus:outline-none"
+          >
+            <img
+              src={isEmojiOpen ? emojiOn : emoji}
+              alt="emoji"
+              className="w-[24px] h-[24px]"
+            />
+          </button>
+
+          {/* 선택된 이모지 표시 영역 */}
+          <div className="flex-1 flex flex-col gap-2">
+            {selectedEmoji && (
+              <div className="relative w-fit gap-x-[8px] flex flex-row items-start">
+                <img
+                  src={selectedEmoji.src}
+                  alt={selectedEmoji.label}
+                  className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px] items-center"
+                />
+                <button
+                  onClick={onRemoveEmoji}
+                  className="w-[16px] h-[16px] flex items-center justify-center bg-white rounded-full text-sub-text"
+                >
+                  <img src={X} alt="X" className="w-[16px] h-[16px]" />
+                </button>
+              </div>
+            )}
+
+            {/* 입력 필드 */}
+            <textarea
+              value={commentText}
+              onChange={(e) => {
+                onCommentTextChange(e.target.value);
+                // 높이 자동 조절
+                e.target.style.height = "auto";
+                e.target.style.height = `${e.target.scrollHeight}px`;
+              }}
+              placeholder="따뜻한 공감과 이해의 댓글을 남겨주세요."
+              className="flex-1 max-h-[120px] py-[8px] rounded-[8px] body !line-height-1 text-text focus:outline-none resize-none overflow-y-auto"
+              rows={1}
+              onKeyDown={(e) => {
+                // Shift + Enter: 줄바꿈, Enter만: 전송
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  onSend();
+                }
+              }}
+            />
+          </div>
+
+          {/* 전송 버튼 */}
+          <div
+            onClick={onSend}
+            className="w-[24px] h-[24px] flex items-center justify-center bg-none flex-shrink-0 my-auto cursor-pointer"
+          >
+            <img src={send} alt="send" className="w-[24px] h-[24px]" />
+          </div>
+        </div>
+      </div>
+      <div className="px-5 max-px-[20px] border-t border-[#EAEAEA] bg-outline">
+        <div className="flex flex-col">
+          {/* 이모지 선택 그리드는 CommentBottomSheet에서 처리 */}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommentInput;
+

--- a/src/components/daily-question/CommentItem.tsx
+++ b/src/components/daily-question/CommentItem.tsx
@@ -1,0 +1,168 @@
+import more from "../../../public/icon/more.svg";
+import send from "../../../public/icon/send.svg";
+import X from "../../../public/icon/X.svg";
+import type { Comment, Emoji } from "../../types/daily-question";
+
+interface CommentItemProps {
+  comment: Comment;
+  emoji?: Emoji | null;
+  isLast: boolean;
+  openMenuId: number | null;
+  isEditing: boolean;
+  editingText: string;
+  editingSelectedEmoji: Emoji | null;
+  emojiList?: Emoji[];
+  currentUserId: number | null;
+  onMoreClick: (commentId: number, e: React.MouseEvent) => void;
+  onEdit: (commentId: number) => void;
+  onDelete: (commentId: number) => void;
+  onEditingTextChange: (text: string) => void;
+  onEditingEmojiSelect?: (emoji: Emoji) => void;
+  onEditingRemoveEmoji: () => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+}
+
+const CommentItem = ({
+  comment,
+  emoji,
+  isLast,
+  openMenuId,
+  isEditing,
+  editingText,
+  editingSelectedEmoji,
+  currentUserId,
+  onMoreClick,
+  onEdit,
+  onDelete,
+  onEditingTextChange,
+  onEditingRemoveEmoji,
+  onSaveEdit,
+  onCancelEdit,
+}: CommentItemProps) => {
+  const isMyComment = currentUserId !== null && comment.userId === currentUserId;
+  if (isEditing) {
+    return (
+      <div
+        className={`flex flex-col gap-3 pb-4 ${
+          !isLast ? "border-b border-[#EAEAEA] pb-4" : ""
+        }`}
+      >
+        <div className="flex flex-row items-start gap-[10px]">
+
+          {/* 선택된 이모지 표시 영역 */}
+          <div className="flex-1 flex flex-col gap-2">
+            {editingSelectedEmoji && (
+              <div className="relative w-fit gap-x-[8px] flex flex-row items-start">
+                <img
+                  src={editingSelectedEmoji.src}
+                  alt={editingSelectedEmoji.label}
+                  className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px] items-center"
+                />
+                <button
+                  onClick={onEditingRemoveEmoji}
+                  className="w-[16px] h-[16px] flex items-center justify-center bg-white rounded-full text-sub-text"
+                >
+                  <img src={X} alt="X" className="w-[16px] h-[16px]" />
+                </button>
+              </div>
+            )}
+
+            {/* 입력 필드 */}
+            <textarea
+              value={editingText}
+              onChange={(e) => {
+                onEditingTextChange(e.target.value);
+                // 높이 자동 조절
+                e.target.style.height = "auto";
+                e.target.style.height = `${e.target.scrollHeight}px`;
+              }}
+              placeholder="댓글을 수정해주세요."
+              className="flex-1 max-h-[120px] py-[8px] px-3 rounded-[8px] body !line-height-1 text-text focus:outline-none resize-none overflow-y-auto border border-[#EAEAEA]"
+              rows={1}
+            />
+          </div>
+
+          {/* 저장/취소 버튼 */}
+          <div className="flex flex-col gap-2 flex-shrink-0 mt-2">
+            <button
+              onClick={onSaveEdit}
+              className="w-[24px] h-[24px] flex items-center justify-center bg-none"
+            >
+              <img src={send} alt="save" className="w-[24px] h-[24px]" />
+            </button>
+            <button
+              onClick={onCancelEdit}
+              className="w-[24px] h-[24px] flex items-center justify-center bg-none text-sub-text body"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex flex-row gap-3 pb-4 ${
+        !isLast ? "border-b border-[#EAEAEA] pb-4" : ""
+      }`}
+    >
+      <div className="flex-1 flex flex-col gap-y-[8px] pl-[12px]">
+        <div className="flex flex-row items-center gap-[8px]">
+          <div className="label-bold text-text">{comment.userName}</div>
+          <div className="caption text-sub-text">{comment.timeAgo}</div>
+        </div>
+        <div className="flex flex-col items-start gap-2 pl-[12px] flex-wrap">
+          {emoji && (
+            <img
+              src={emoji.src}
+              alt={emoji.label}
+              className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px]"
+            />
+          )}
+          {comment.hasContent && comment.content && (
+            <div className="body text-text">{comment.content}</div>
+          )}
+        </div>
+      </div>
+
+      {/* 옵션 메뉴 - 본인 댓글에만 표시 */}
+      {isMyComment && (
+        <div className="relative flex-shrink-0 mr-5">
+          <button
+            onClick={(e) => onMoreClick(comment.id, e)}
+            className="w-6 h-6 flex items-center justify-center focus:outline-none"
+          >
+            <img src={more} alt="more" className="w-6 h-6" />
+          </button>
+
+          {/* 팝업 메뉴 */}
+          {openMenuId === comment.id && (
+            <div
+              className="absolute right-0 top-8 bg-[#FFF6ED] rounded-[4px] flex flex-col shadow-[0_2px_4px_rgba(0,0,0,0.1)] z-10 min-w-[81px]"
+              style={{ boxShadow: "0px 2px 4px rgba(0,0,0,0.1)" }}
+            >
+              <button
+                onClick={() => onEdit(comment.id)}
+                className="px-4 py-3 body text-text hover:bg-[#FFE5C7] rounded-t-[4px] text-left"
+              >
+                수정하기
+              </button>
+              <button
+                onClick={() => onDelete(comment.id)}
+                className="px-4 py-3 body text-text hover:bg-[#FFE5C7] rounded-b-[4px] text-left border-t border-[#EAEAEA]"
+              >
+                삭제하기
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommentItem;
+

--- a/src/components/daily-question/EmojiSelector.tsx
+++ b/src/components/daily-question/EmojiSelector.tsx
@@ -1,0 +1,36 @@
+interface Emoji {
+  id: string;
+  label: string;
+  src: string;
+}
+
+interface EmojiSelectorProps {
+  emojiList: Emoji[];
+  onSelect: (emoji: Emoji) => void;
+}
+
+const EmojiSelector = ({ emojiList, onSelect }: EmojiSelectorProps) => {
+  return (
+    <div className="flex flex-col gap-[16px] pt-[24px] z-[999]">
+      <div className="label-bold text-text">공감 표현하기</div>
+      <div className="grid grid-cols-3 gap-y-[20px] mb-[7.81vh] max-mb-[66px]">
+        {emojiList.map((emoji) => (
+          <button
+            key={emoji.id}
+            onClick={() => onSelect(emoji)}
+            className="flex items-center justify-center rounded-[8px]"
+          >
+            <img
+              src={emoji.src}
+              alt={emoji.label}
+              className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px] items-center"
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default EmojiSelector;
+

--- a/src/components/daily-question/FamilyMemberItem.tsx
+++ b/src/components/daily-question/FamilyMemberItem.tsx
@@ -1,0 +1,104 @@
+import CommonButton from "../common/CommonButton";
+import lock from "../../../public/icon/lock.svg";
+import down from "../../../public/icon/down.svg";
+
+interface FamilyMember {
+  userId: number;
+  name: string;
+  status: "locked" | "not_answered" | "answered";
+  answer?: string;
+}
+
+interface FamilyMemberItemProps {
+  member: FamilyMember;
+  isAllAnswered: boolean;
+  isExpanded: boolean;
+  isNudged: boolean;
+  onToggle: () => void;
+  onNudge: () => void;
+}
+
+const FamilyMemberItem = ({
+  member,
+  isAllAnswered,
+  isExpanded,
+  isNudged,
+  onToggle,
+  onNudge,
+}: FamilyMemberItemProps) => {
+  return (
+    <div
+      className={`
+        w-full
+        bg-bg
+        rounded-[4px]
+        py-[16px] px-5
+        flex flex-col gap-y-[8px]
+        border-b border-[#EAEAEA]
+      `}
+    >
+      {/* 상태에 따른 표시 */}
+      {isAllAnswered && member.status === "answered" && (
+        <>
+          <div className="flex flex-row items-center justify-between">
+            <div className="label-bold text-text">{member.name}</div>
+            <button
+              onClick={onToggle}
+              className="w-[16px] h-[16px] flex items-center justify-center focus:outline-none"
+            >
+              <img
+                src={down}
+                alt="down"
+                className={`w-[16px] h-[16px] transition-transform duration-300 ${
+                  isExpanded ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+          </div>
+          <div
+            className={`px-[12px] body text-text overflow-hidden transition-all duration-300 ease-in-out ${
+              !isExpanded ? "line-clamp-2" : ""
+            }`}
+            style={{
+              maxHeight: isExpanded ? "1000px" : "2.8em",
+            }}
+          >
+            {member.answer}
+          </div>
+        </>
+      )}
+
+      {!isAllAnswered && (
+        <>
+          {/* 멤버 이름 */}
+          <div className="label-bold text-text">{member.name}</div>
+        </>
+      )}
+
+      {!isAllAnswered && member.status === "locked" && (
+        <div className="flex flex-row items-center gap-[4px] pl-[12px]">
+          <img src={lock} alt="lock" className="w-[16px] h-[16px] items-center" />
+          <div className="body text-sub-text">아직 답변 공개 전이에요.</div>
+        </div>
+      )}
+
+      {!isAllAnswered && member.status === "not_answered" && (
+        <div className="flex flex-row items-center justify-between px-[12px]">
+          <div className="body text-sub-text">아직 답변을 작성하지 않았어요.</div>
+          <CommonButton
+            label="마음 두드리기"
+            bgColor="bg-sub-1"
+            textColor={isNudged ? "text-[#ffffff] body" : "text-text body"}
+            className="!w-fit !rounded-[8px]"
+            padding="px-4 py-2.5"
+            onClick={onNudge}
+            disabled={isNudged || false}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FamilyMemberItem;
+

--- a/src/components/daily-question/FamilyMemberList.tsx
+++ b/src/components/daily-question/FamilyMemberList.tsx
@@ -1,0 +1,61 @@
+import FamilyMemberItem from "./FamilyMemberItem";
+import MyAnswerCard from "./MyAnswerCard";
+
+interface FamilyMember {
+  userId: number;
+  name: string;
+  status: "locked" | "not_answered" | "answered";
+  answer?: string;
+}
+
+interface FamilyMemberListProps {
+  myAnswered: boolean;
+  myAnswer: string;
+  isMyAnswerExpanded: boolean;
+  familyMembers: FamilyMember[];
+  isAllAnswered: boolean;
+  expandedMembers: Record<string, boolean>;
+  nudgedMembers: Record<string, boolean>;
+  onToggleMyAnswer: () => void;
+  onToggleMemberAnswer: (memberName: string) => void;
+  onNudge: (memberName: string) => void;
+}
+
+const FamilyMemberList = ({
+  myAnswered,
+  myAnswer,
+  isMyAnswerExpanded,
+  familyMembers,
+  isAllAnswered,
+  expandedMembers,
+  nudgedMembers,
+  onToggleMyAnswer,
+  onToggleMemberAnswer,
+  onNudge,
+}: FamilyMemberListProps) => {
+  return (
+    <div className="flex flex-col">
+      {myAnswered && (
+        <MyAnswerCard
+          answer={myAnswer}
+          isExpanded={isMyAnswerExpanded}
+          onToggle={onToggleMyAnswer}
+        />
+      )}
+      {familyMembers.map((member) => (
+        <FamilyMemberItem
+          key={member.userId}
+          member={member}
+          isAllAnswered={isAllAnswered}
+          isExpanded={expandedMembers[member.name] || false}
+          isNudged={nudgedMembers[member.name] || false}
+          onToggle={() => onToggleMemberAnswer(member.name)}
+          onNudge={() => onNudge(member.name)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FamilyMemberList;
+

--- a/src/components/daily-question/InfoMessage.tsx
+++ b/src/components/daily-question/InfoMessage.tsx
@@ -1,0 +1,21 @@
+interface InfoMessageProps {
+  isVisible: boolean;
+}
+
+const InfoMessage = ({ isVisible }: InfoMessageProps) => {
+  if (!isVisible) return null;
+
+  return (
+    <div className="flex flex-row items-center gap-2 px-5 mb-[2.36vh] max-mb-[20px] mt-[2.36vh] max-mt-[20px]">
+      <div className="w-4 h-4 rounded-full bg-none border border-sub-text flex items-center justify-center">
+        <span className="text-sub-text text-[10px] font-bold">!</span>
+      </div>
+      <div className="body text-sub-text">
+        모든 멤버가 답변을 작성해야 답안이 공개돼요.
+      </div>
+    </div>
+  );
+};
+
+export default InfoMessage;
+

--- a/src/components/daily-question/MessageButton.tsx
+++ b/src/components/daily-question/MessageButton.tsx
@@ -1,0 +1,19 @@
+import message from "../../../public/icon/message.svg";
+
+interface MessageButtonProps {
+  onClick: () => void;
+}
+
+const MessageButton = ({ onClick }: MessageButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-[72px] right-[20px] w-12 h-12 !rounded-full bg-sub-1 flex items-center justify-center shadow-[2px_2px_4px_rgba(0,0,0,0.12)] z-10"
+    >
+      <img src={message} alt="message" className="w-6 h-6" />
+    </button>
+  );
+};
+
+export default MessageButton;
+

--- a/src/components/daily-question/MyAnswerCard.tsx
+++ b/src/components/daily-question/MyAnswerCard.tsx
@@ -1,0 +1,52 @@
+import down from "../../../public/icon/down.svg";
+
+interface MyAnswerCardProps {
+  answer: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const MyAnswerCard = ({ answer, isExpanded, onToggle }: MyAnswerCardProps) => {
+  return (
+    <div
+      className={`
+        w-full
+        bg-bg
+        rounded-[4px]
+        py-[16px] px-5
+        flex flex-col gap-y-[8px]
+        border-b border-[#EAEAEA]
+      `}
+    >
+      {/* 멤버 이름 */}
+      <div className="flex flex-row items-center justify-between">
+        <div className="label-bold text-text">나</div>
+        <button
+          onClick={onToggle}
+          className="w-[16px] h-[16px] flex items-center justify-center focus:outline-none"
+        >
+          <img
+            src={down}
+            alt="down"
+            className={`w-[16px] h-[16px] transition-transform duration-300 ${
+              isExpanded ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+      </div>
+      <div
+        className={`px-[12px] body text-text overflow-hidden transition-all duration-300 ease-in-out ${
+          !isExpanded ? "line-clamp-2" : ""
+        }`}
+        style={{
+          maxHeight: isExpanded ? "1000px" : "2.8em",
+        }}
+      >
+        {answer}
+      </div>
+    </div>
+  );
+};
+
+export default MyAnswerCard;
+

--- a/src/components/daily-question/QuestionCard.tsx
+++ b/src/components/daily-question/QuestionCard.tsx
@@ -1,0 +1,60 @@
+import CommonButton from "../common/CommonButton";
+
+interface QuestionCardProps {
+  questionNumber: number;
+  question: string;
+  myAnswered: boolean;
+  onAnswerClick: () => void;
+}
+
+const QuestionCard = ({
+  questionNumber,
+  question,
+  myAnswered,
+  onAnswerClick,
+}: QuestionCardProps) => {
+  return (
+    <div
+      className="w-full
+        bg-gradient-to-b from-[#FFFFFD] to-[#FFF6ED]
+        rounded-b-[20px]
+        shadow-[0_4px_8px_rgba(0,0,0,0.08)]
+        flex flex-col gap-y-[1.42vh] max-gap-y-[12px]
+        pt-[60px] px-5 pb-6"
+    >
+      {/* 질문 번호 */}
+      <div className="bg-sub-1 text-main py-1 px-2 w-fit rounded">
+        Q{questionNumber}
+      </div>
+
+      {/* 질문 텍스트 */}
+      <div className="title text-text break-keep break-words">
+        {question}
+      </div>
+
+      {/* 답변하러 가기 버튼 */}
+      {!myAnswered && (
+        <CommonButton
+          label="답변하러 가기"
+          img="/icon/next.svg"
+          className="body-bold !rounded-[8px]"
+          width="w-fit"
+          padding="px-[12px] py-[8px]"
+          onClick={onAnswerClick}
+        />
+      )}
+      {myAnswered && (
+        <CommonButton
+          label="답변 완료"
+          className="body-bold !rounded-[8px]"
+          width="w-fit"
+          padding="px-[12px] py-[8px]"
+          disabled={true}
+        />
+      )}
+    </div>
+  );
+};
+
+export default QuestionCard;
+

--- a/src/components/home/GradientBox.tsx
+++ b/src/components/home/GradientBox.tsx
@@ -1,15 +1,69 @@
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { LevelItem } from "../../constants/home";
 import CommonButton from "../common/CommonButton";
 import DOMPurify from "dompurify";
+import { getTodayQuestion } from "../../api/daily-question";
 
 interface GradientBoxProps {
-  questionDummy: string;
-  descDummy: string;
+  descDummy?: string;
 }
 
-const GradientBox = ({ questionDummy, descDummy }: GradientBoxProps) => {
+const GradientBox = ({ descDummy }: GradientBoxProps) => {
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [questionData, setQuestionData] = useState({
+    dailyQuestionId: 0,
+    questionNumber: 0,
+    questionText: "",
+  });
+
+  useEffect(() => {
+    const loadQuestion = async () => {
+      try {
+        const response = await getTodayQuestion();
+        const data = response.data;
+        setQuestionData({
+          dailyQuestionId: data.dailyQuestionId,
+          questionNumber: data.questionNumber,
+          questionText: data.questionText,
+        });
+      } catch (error: any) {
+        console.error("질문 조회 실패:", error);
+        // 에러 발생 시 기본값 유지
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadQuestion();
+  }, []);
+
+  const handleAnswerClick = () => {
+    navigate("/answer", {
+      state: {
+        dailyQuestionId: questionData.dailyQuestionId,
+        questionNumber: questionData.questionNumber,
+        question: questionData.questionText,
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        className="min-h-[380px]
+          bg-linear-to-b from-[#FFFFFD] to-[#FFF6ED]
+          rounded-b-[20px]
+          shadow-[0_4px_8px_rgba(0,0,0,0.08)]
+          flex flex-col gap-y-10
+          py-6 px-5
+          items-center justify-center"
+      >
+        <div className="body text-text">질문을 불러오는 중...</div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -35,17 +89,19 @@ const GradientBox = ({ questionDummy, descDummy }: GradientBoxProps) => {
       {/* question */}
       <div className="flex flex-col gap-y-[12px]">
         {/* question # */}
-        <div className="bg-sub-1 text-main py-1 px-2 w-fit">Q1</div>
+        <div className="bg-sub-1 text-main py-1 px-2 w-fit">
+          Q{questionData.questionNumber}
+        </div>
         {/* question */}
         <div
           dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(questionDummy),
+            __html: DOMPurify.sanitize(questionData.questionText),
           }}
-          className="title"
+          className="title break-keep break-words"
         />
         {/* ans btn */}
         <CommonButton
-          onClick={() => navigate("/answer")}
+          onClick={handleAnswerClick}
           label="답변하러 가기"
           img="/icon/next.svg"
           className="body-bold"

--- a/src/constants/daily-question.ts
+++ b/src/constants/daily-question.ts
@@ -1,0 +1,17 @@
+import emojiThx from "../../public/icon/emojiThx.svg";
+import emojiSry from "../../public/icon/emojiSry.svg";
+import emojiLuv from "../../public/icon/emojiLuv.svg";
+import emojiBest from "../../public/icon/emojiBest.svg";
+import emojiOk from "../../public/icon/emojiOk.svg";
+import emojiUnderstand from "../../public/icon/emojiUnderstand.svg";
+import type { Emoji } from "../types/daily-question";
+
+export const EMOJI_LIST: Emoji[] = [
+  { id: "thx", label: "고마워요", src: emojiThx },
+  { id: "sry", label: "미안해요..", src: emojiSry },
+  { id: "luv", label: "사랑해요", src: emojiLuv },
+  { id: "best", label: "최고예요!", src: emojiBest },
+  { id: "ok", label: "괜찮아요", src: emojiOk },
+  { id: "understand", label: "이해해요", src: emojiUnderstand },
+];
+

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,0 +1,270 @@
+import { useState, useEffect } from "react";
+import { getComments, createComment, updateComment, deleteComment as deleteCommentApi } from "../api/comment";
+import { transformComment, parseBothContent, getEmojiById } from "../utils/daily-question";
+import { formatTimeAgo } from "../utils/daily-question";
+import type { Comment } from "../types/daily-question";
+import type { Emoji } from "../types/daily-question";
+
+interface UseCommentsProps {
+  dailyQuestionId: number;
+}
+
+export const useComments = ({ dailyQuestionId }: UseCommentsProps) => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [commentText, setCommentText] = useState("");
+  const [isEmojiOpen, setIsEmojiOpen] = useState(false);
+  const [selectedEmoji, setSelectedEmoji] = useState<Emoji | null>(null);
+  const [openMenuId, setOpenMenuId] = useState<number | null>(null);
+  const [deleteCommentId, setDeleteCommentId] = useState<number | null>(null);
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editingCommentText, setEditingCommentText] = useState("");
+  const [editingSelectedEmoji, setEditingSelectedEmoji] = useState<Emoji | null>(null);
+
+  // dailyQuestionId가 변경되면 댓글 초기화
+  useEffect(() => {
+    if (dailyQuestionId > 0) {
+      setComments([]);
+      setCommentText("");
+      setSelectedEmoji(null);
+      setOpenMenuId(null);
+      setDeleteCommentId(null);
+    }
+  }, [dailyQuestionId]);
+
+  const loadComments = async () => {
+    if (dailyQuestionId <= 0) {
+      console.warn("dailyQuestionId가 유효하지 않음:", dailyQuestionId);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await getComments(dailyQuestionId);
+      const transformedComments = response.data.map(transformComment);
+      setComments(transformedComments);
+    } catch (error: any) {
+      console.error("댓글 조회 실패:", error);
+      console.error("에러 상세:", {
+        message: error?.message,
+        response: error?.response,
+        status: error?.status,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const sendComment = async () => {
+    if (!commentText.trim() && !selectedEmoji) {
+      return;
+    }
+
+    if (!dailyQuestionId) {
+      alert("질문 정보가 없습니다.");
+      return;
+    }
+
+    try {
+      // 타입과 content 결정
+      let type: "TEXT" | "EMOJI" | "BOTH";
+      let content: string;
+
+      if (selectedEmoji && commentText.trim()) {
+        // BOTH: "이모지ID|텍스트" 형식
+        type = "BOTH";
+        content = `${selectedEmoji.id}|${commentText.trim()}`;
+      } else if (selectedEmoji) {
+        // EMOJI: 이모지 ID만
+        type = "EMOJI";
+        content = selectedEmoji.id;
+      } else {
+        // TEXT: 텍스트만
+        type = "TEXT";
+        content = commentText.trim();
+      }
+
+      // API 호출
+      const response = await createComment({
+        dailyQuestionId,
+        content,
+        type,
+      });
+
+      // API 응답을 Comment 인터페이스에 맞게 변환
+      let emojiId: string | undefined;
+      let contentText: string = "";
+      let hasContent: boolean = false;
+
+      if (response.data.type === "EMOJI") {
+        emojiId = response.data.content;
+        contentText = "";
+        hasContent = false;
+      } else if (response.data.type === "BOTH") {
+        const parsed = parseBothContent(response.data.content);
+        emojiId = parsed.emojiId || undefined;
+        contentText = parsed.text;
+        hasContent = !!contentText;
+      } else {
+        emojiId = undefined;
+        contentText = response.data.content;
+        hasContent = !!contentText;
+      }
+
+      const newComment: Comment = {
+        id: response.data.commentId,
+        userId: response.data.userId,
+        userName: response.data.userNickname,
+        timeAgo: formatTimeAgo(response.data.createdAt),
+        emoji: emojiId,
+        content: contentText,
+        hasContent: hasContent,
+      };
+
+      // 댓글 리스트에 추가 (최신 댓글이 위로)
+      setComments((prev) => [newComment, ...prev]);
+      setCommentText("");
+      setSelectedEmoji(null);
+    } catch (error: any) {
+      console.error("댓글 전송 실패:", error);
+      const errorMessage =
+        error?.response?.message ||
+        error?.message ||
+        "댓글을 전송하는 중 오류가 발생했습니다.";
+      alert(errorMessage);
+    }
+  };
+
+  const deleteComment = async () => {
+    if (!deleteCommentId) return;
+
+    try {
+      await deleteCommentApi(deleteCommentId);
+      setComments((prev) => prev.filter((comment) => comment.id !== deleteCommentId));
+      setDeleteCommentId(null);
+    } catch (error: any) {
+      console.error("댓글 삭제 실패:", error);
+      const errorMessage =
+        error?.response?.message ||
+        error?.message ||
+        "댓글을 삭제하는 중 오류가 발생했습니다.";
+      alert(errorMessage);
+    }
+  };
+
+  const startEditComment = (commentId: number) => {
+    const comment = comments.find((c) => c.id === commentId);
+    if (!comment) return;
+
+    setEditingCommentId(commentId);
+    setEditingCommentText(comment.content);
+    // 이모지가 있으면 찾아서 설정
+    const emoji = comment.emoji ? getEmojiById(comment.emoji) : null;
+    setEditingSelectedEmoji(emoji);
+    setOpenMenuId(null);
+  };
+
+  const cancelEditComment = () => {
+    setEditingCommentId(null);
+    setEditingCommentText("");
+    setEditingSelectedEmoji(null);
+  };
+
+  const saveEditComment = async () => {
+    if (!editingCommentId) return;
+
+    if (!editingCommentText.trim() && !editingSelectedEmoji) {
+      alert("댓글 내용을 입력해주세요.");
+      return;
+    }
+
+    try {
+      // 타입과 content 결정
+      let type: "TEXT" | "EMOJI" | "BOTH";
+      let content: string;
+
+      if (editingSelectedEmoji && editingCommentText.trim()) {
+        type = "BOTH";
+        content = `${editingSelectedEmoji.id}|${editingCommentText.trim()}`;
+      } else if (editingSelectedEmoji) {
+        type = "EMOJI";
+        content = editingSelectedEmoji.id;
+      } else {
+        type = "TEXT";
+        content = editingCommentText.trim();
+      }
+
+      const response = await updateComment(editingCommentId, { content, type });
+
+      // API 응답을 Comment 인터페이스에 맞게 변환
+      let emojiId: string | undefined;
+      let contentText: string = "";
+      let hasContent: boolean = false;
+
+      if (response.data.type === "EMOJI") {
+        emojiId = response.data.content;
+        contentText = "";
+        hasContent = false;
+      } else if (response.data.type === "BOTH") {
+        const parsed = parseBothContent(response.data.content);
+        emojiId = parsed.emojiId || undefined;
+        contentText = parsed.text;
+        hasContent = !!contentText;
+      } else {
+        emojiId = undefined;
+        contentText = response.data.content;
+        hasContent = !!contentText;
+      }
+
+      const updatedComment: Comment = {
+        id: response.data.commentId,
+        userId: response.data.userId,
+        userName: response.data.userNickname,
+        timeAgo: formatTimeAgo(response.data.updatedAt),
+        emoji: emojiId,
+        content: contentText,
+        hasContent: hasContent,
+      };
+
+      // 댓글 리스트 업데이트
+      setComments((prev) =>
+        prev.map((comment) => (comment.id === editingCommentId ? updatedComment : comment))
+      );
+      cancelEditComment();
+    } catch (error: any) {
+      console.error("댓글 수정 실패:", error);
+      const errorMessage =
+        error?.response?.message ||
+        error?.message ||
+        "댓글을 수정하는 중 오류가 발생했습니다.";
+      alert(errorMessage);
+    }
+  };
+
+  return {
+    comments,
+    isLoading,
+    commentText,
+    isEmojiOpen,
+    selectedEmoji,
+    openMenuId,
+    deleteCommentId,
+    editingCommentId,
+    editingCommentText,
+    editingSelectedEmoji,
+    setCommentText,
+    setIsEmojiOpen,
+    setSelectedEmoji,
+    setOpenMenuId,
+    setDeleteCommentId,
+    setEditingCommentText,
+    setEditingSelectedEmoji,
+    loadComments,
+    sendComment,
+    deleteComment,
+    startEditComment,
+    cancelEditComment,
+    saveEditComment,
+  };
+};
+

--- a/src/hooks/useDailyQuestion.ts
+++ b/src/hooks/useDailyQuestion.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect } from "react";
+import { getTodayQuestion } from "../api/daily-question";
+import { transformFamilyMembers } from "../utils/daily-question";
+import type { FamilyMember, QuestionData } from "../types/daily-question";
+
+export const useDailyQuestion = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [questionData, setQuestionData] = useState<QuestionData>({
+    dailyQuestionId: 0,
+    questionNumber: 0,
+    question: "",
+    isAllAnswered: false,
+    myAnswered: false,
+    myAnswer: "",
+  });
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
+  const [myUserId, setMyUserId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const loadQuestionData = async () => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const response = await getTodayQuestion();
+        const data = response.data;
+
+        // 현재 사용자 찾기 (일단 answered가 true이고 answerContent가 있는 첫 번째를 현재 사용자로 가정)
+        // TODO: 실제로는 JWT 토큰에서 userId를 가져오거나 별도 API 호출 필요
+        const myMember = data.members.find((m) => m.answered && m.answerContent);
+        const currentUserId = myMember?.userId || data.members[0]?.userId || null;
+        setMyUserId(currentUserId);
+
+        // 질문 데이터 설정
+        setQuestionData({
+          dailyQuestionId: data.dailyQuestionId,
+          questionNumber: data.questionNumber,
+          question: data.questionText,
+          isAllAnswered: data.isAllAnswered,
+          myAnswered: myMember?.answered || false,
+          myAnswer: myMember?.answerContent || "",
+        });
+
+        // 가족 멤버 데이터 변환
+        const transformedMembers = transformFamilyMembers(
+          data.members,
+          currentUserId,
+          data.isAllAnswered
+        );
+        setFamilyMembers(transformedMembers);
+      } catch (error: any) {
+        const errorMessage =
+          error?.response?.message ||
+          error?.message ||
+          "질문을 불러오는 중 오류가 발생했습니다.";
+        setError(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadQuestionData();
+  }, []);
+
+  return {
+    isLoading,
+    error,
+    questionData,
+    familyMembers,
+    myUserId,
+  };
+};
+

--- a/src/pages/DailyQuestion.tsx
+++ b/src/pages/DailyQuestion.tsx
@@ -2,20 +2,15 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import CommonButton from "../components/common/CommonButton";
 import CommonModal from "../components/common/CommonModal";
-import lock from "../../public/icon/lock.svg";
-import down from "../../public/icon/down.svg";
-import message from "../../public/icon/message.svg";
-import send from "../../public/icon/send.svg";
-import more from "../../public/icon/more.svg";
-import emoji from "../../public/icon/emoji.svg";
-import emojiOn from "../../public/icon/emojiOn.svg";
-import emojiThx from "../../public/icon/emojiThx.svg";
-import emojiSry from "../../public/icon/emojiSry.svg";
-import emojiLuv from "../../public/icon/emojiLuv.svg";
-import emojiBest from "../../public/icon/emojiBest.svg";
-import emojiOk from "../../public/icon/emojiOk.svg";
-import emojiUnderstand from "../../public/icon/emojiUnderstand.svg";
-import X from "../../public/icon/X.svg";
+import QuestionCard from "../components/daily-question/QuestionCard";
+import InfoMessage from "../components/daily-question/InfoMessage";
+import FamilyMemberList from "../components/daily-question/FamilyMemberList";
+import MessageButton from "../components/daily-question/MessageButton";
+import CommentBottomSheet from "../components/daily-question/CommentBottomSheet";
+import { useDailyQuestion } from "../hooks/useDailyQuestion";
+import { useComments } from "../hooks/useComments";
+import { getEmojiById } from "../utils/daily-question";
+import { EMOJI_LIST } from "../constants/daily-question";
 
 const DailyQuestion = () => {
   const navigate = useNavigate();
@@ -23,69 +18,43 @@ const DailyQuestion = () => {
   const [expandedMembers, setExpandedMembers] = useState<Record<string, boolean>>({});
   const [nudgedMembers, setNudgedMembers] = useState<Record<string, boolean>>({});
   const [isCommentOpen, setIsCommentOpen] = useState(false);
-  const [commentText, setCommentText] = useState("");
-  const [isEmojiOpen, setIsEmojiOpen] = useState(false);
-  const [selectedEmoji, setSelectedEmoji] = useState<{ id: string; label: string; src: string } | null>(null);
-  const [openMenuId, setOpenMenuId] = useState<number | null>(null);
-  const [deleteCommentId, setDeleteCommentId] = useState<number | null>(null);
-  
-  // TODO: API에서 댓글 데이터 받아오기
-  const [comments, setComments] = useState([
-    {
-      id: 1,
-      userName: "혜린",
-      timeAgo: "지금",
-      emoji: "best",
-      content: "",
-      hasContent: true,
-    },
-    {
-      id: 2,
-      userName: "혜린",
-      timeAgo: "2분 전",
-      content: "저도 그 때 대화가 기억에 남아요.",
-      hasContent: true,
-    },
-    {
-      id: 3,
-      userName: "혜린",
-      timeAgo: "2분 전",
-      content: "저도 그 때 대화가 기억에 남아요.",
-      hasContent: true,
-    },
-  ]);
 
-  // TODO: API에서 질문 데이터 받아오기
-  const questionData = {
-    questionNumber: 1,
-    question: "가족과 최근 나눴던 대화 중 가장 기억에 남는 순간은 언제인가요?",
-    isAllAnswered: true,
-    myAnswered: true,
-    myAnswer: "며칠 전 엄마가 밤늦게 과일 깎아서 방에 가져다주셨어요. 아무 말 안 했는데도 제가 힘든 걸 느끼고 챙겨주는 게 느껴져서 기분이 좋았어요.",
-  };
-
-  // TODO: API에서 가족 멤버 답변 상태 받아오기
-  const familyMembers = [
-    {
-      name: "엄마",
-      status: "answered", // "locked" | "not_answered" | "answered"
-      answer: "며칠 전에 늦게까지 공부하느라 힘들어 보이길래 간식 챙겨주면서 잠깐 이야기했어요. 별 말은 아니었지만 그냥 곁에 있어주는 게 좋았어요.",
-    },
-    {
-      name: "아빠",
-      status: "answered",
-      answer: "주말에 같이 차 타고 가다가 이런저런 얘기를 나눴는데, 진로에 대해 진지하게 상의해준 게 오랜만이었어요.",
-    },
-    {
-      name: "동생",
-      status: "answered",
-      answer: "요즘 학교 생활이 힘들다고 말하길래 같이 산책하면서 이야기해줬어요. 평소엔 투덜거리기만 하는데 그날은 진심으로 들어줘서 고마웠어요.",
-    },
-  ];
+  // Custom Hooks
+  const { isLoading, error, questionData, familyMembers, myUserId } = useDailyQuestion();
+  const {
+    comments,
+    isLoading: isCommentsLoading,
+    commentText,
+    isEmojiOpen,
+    selectedEmoji,
+    openMenuId,
+    deleteCommentId,
+    editingCommentId,
+    editingCommentText,
+    editingSelectedEmoji,
+    setCommentText,
+    setIsEmojiOpen,
+    setSelectedEmoji,
+    setOpenMenuId,
+    setDeleteCommentId,
+    setEditingCommentText,
+    setEditingSelectedEmoji,
+    loadComments,
+    sendComment,
+    deleteComment,
+    startEditComment,
+    cancelEditComment,
+    saveEditComment,
+  } = useComments({ dailyQuestionId: questionData.dailyQuestionId });
 
   const handleAnswerClick = () => {
-    // TODO: 답변 페이지로 이동
-    navigate("/answer");
+    navigate("/answer", {
+      state: {
+        dailyQuestionId: questionData.dailyQuestionId,
+        questionNumber: questionData.questionNumber,
+        question: questionData.question,
+      },
+    });
   };
 
   const handleNudgeClick = (memberName: string) => {
@@ -97,10 +66,7 @@ const DailyQuestion = () => {
     }));
   };
 
-  const handleToggleAnswer = () => {
-    setIsAnswerExpanded(!isAnswerExpanded);
-  };
-
+  const handleToggleAnswer = () => setIsAnswerExpanded(!isAnswerExpanded);
   const handleToggleMemberAnswer = (memberName: string) => {
     setExpandedMembers((prev) => ({
       ...prev,
@@ -108,54 +74,16 @@ const DailyQuestion = () => {
     }));
   };
 
-  const handleMessageClick = () => {
+  const handleMessageClick = async () => {
     setIsCommentOpen(true);
+    await loadComments();
   };
 
-  const handleCloseComment = () => {
-    setIsCommentOpen(false);
-  };
+  const handleCloseComment = () => setIsCommentOpen(false);
 
-  const handleSendComment = () => {
-    if (!commentText.trim() && !selectedEmoji) {
-      return;
-    }
-    // TODO: 댓글 전송 API 호출 (commentText와 selectedEmoji 전달)
-    console.log("댓글 전송:", commentText, selectedEmoji);
-    
-    // 임시로 댓글 리스트에 추가 (실제로는 API 응답으로 처리)
-    const newComment = {
-      id: comments.length + 1,
-      userName: "나", // TODO: 실제 사용자 이름
-      timeAgo: "지금",
-      emoji: selectedEmoji?.id || undefined,
-      content: commentText.trim(),
-      hasContent: !!commentText.trim(),
-    };
-    
-    setComments((prev) => [newComment, ...prev]);
-    setCommentText("");
-    setSelectedEmoji(null);
-  };
-
-  // 이모지 ID를 이미지로 매핑
-  const getEmojiById = (emojiId?: string) => {
-    if (!emojiId) return null;
-    return emojiList.find(emoji => emoji.id === emojiId);
-  };
-
-  const handleEmojiToggle = () => {
-    setIsEmojiOpen(!isEmojiOpen);
-  };
-
-  const handleEmojiSelect = (emoji: { id: string; label: string; src: string }) => {
-    setSelectedEmoji(emoji);
-    // setIsEmojiOpen(false);
-  };
-
-  const handleRemoveEmoji = () => {
-    setSelectedEmoji(null);
-  };
+  const handleEmojiToggle = () => setIsEmojiOpen(!isEmojiOpen);
+  const handleEmojiSelect = (emoji: { id: string; label: string; src: string }) => setSelectedEmoji(emoji);
+  const handleRemoveEmoji = () => setSelectedEmoji(null);
 
   const handleMoreClick = (commentId: number, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -163,9 +91,7 @@ const DailyQuestion = () => {
   };
 
   const handleEditComment = (commentId: number) => {
-    // TODO: 댓글 수정 기능
-    console.log("댓글 수정:", commentId);
-    setOpenMenuId(null);
+    startEditComment(commentId);
   };
 
   const handleDeleteComment = (commentId: number) => {
@@ -173,397 +99,90 @@ const DailyQuestion = () => {
     setOpenMenuId(null);
   };
 
-  const handleConfirmDelete = () => {
-    if (deleteCommentId) {
-      // TODO: 댓글 삭제 API 호출
-      console.log("댓글 삭제:", deleteCommentId);
-      setComments((prev) => prev.filter((comment) => comment.id !== deleteCommentId));
-      setDeleteCommentId(null);
-    }
-  };
+  const handleConfirmDelete = () => deleteComment();
+  const handleCancelDelete = () => setDeleteCommentId(null);
 
-  const handleCancelDelete = () => {
-    setDeleteCommentId(null);
-  };
+  if (isLoading) {
+    return (
+      <div className="w-full h-screen flex items-center justify-center">
+        <div className="body text-text">질문을 불러오는 중...</div>
+      </div>
+    );
+  }
 
-  const emojiList = [
-    { id: "thx", label: "고마워요", src: emojiThx },
-    { id: "sry", label: "미안해요..", src: emojiSry },
-    { id: "luv", label: "사랑해요", src: emojiLuv },
-    { id: "best", label: "최고예요!", src: emojiBest },
-    { id: "ok", label: "괜찮아요", src: emojiOk },
-    { id: "understand", label: "이해해요", src: emojiUnderstand },
-  ];
+  if (error) {
+    return (
+      <div className="w-full h-screen flex flex-col items-center justify-center gap-4">
+        <div className="body text-error">{error}</div>
+        <CommonButton
+          label="다시 시도"
+          onClick={() => window.location.reload()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="w-full flex flex-col">
-      {/* 질문 카드 */}
-      <div
-        className="w-full
-          bg-gradient-to-b from-[#FFFFFD] to-[#FFF6ED]
-          rounded-b-[20px]
-          shadow-[0_4px_8px_rgba(0,0,0,0.08)]
-          flex flex-col gap-y-[1.42vh] max-gap-y-[12px]
-          pt-[60px] px-5 pb-6"
-      >
-        {/* 질문 번호 */}
-        <div className="bg-sub-1 text-main py-1 px-2 w-fit rounded">
-          Q{questionData.questionNumber}
-        </div>
+      <QuestionCard
+        questionNumber={questionData.questionNumber}
+        question={questionData.question}
+        myAnswered={questionData.myAnswered}
+        onAnswerClick={handleAnswerClick}
+      />
 
-        {/* 질문 텍스트 */}
-        <div className="title text-text break-keep break-words">
-          {questionData.question}
-        </div>
+      <InfoMessage isVisible={!questionData.isAllAnswered} />
 
-        {/* 답변하러 가기 버튼 */}
-        {!questionData.myAnswered && (
-        <CommonButton
-          label="답변하러 가기"
-          img="/icon/next.svg"
-          className="body-bold !rounded-[8px]"
-          width="w-fit"
-          padding="px-[12px] py-[8px]"
-          onClick={handleAnswerClick}
-        />
-        )}
-        {questionData.myAnswered && (
-          <CommonButton
-          label="답변 완료"
-          className="body-bold !rounded-[8px]"
-          width="w-fit"
-          padding="px-[12px] py-[8px]"
-          disabled={true}
-        />
-        )}
-      </div>
+      <FamilyMemberList
+        myAnswered={questionData.myAnswered}
+        myAnswer={questionData.myAnswer}
+        isMyAnswerExpanded={isAnswerExpanded}
+        familyMembers={familyMembers}
+        isAllAnswered={questionData.isAllAnswered}
+        expandedMembers={expandedMembers}
+        nudgedMembers={nudgedMembers}
+        onToggleMyAnswer={handleToggleAnswer}
+        onToggleMemberAnswer={handleToggleMemberAnswer}
+        onNudge={handleNudgeClick}
+      />
 
-      {/* 정보 메시지 */}
-      {!questionData.isAllAnswered && (
-      <div className="flex flex-row items-center gap-2 px-5 mb-[2.36vh] max-mb-[20px] mt-[2.36vh] max-mt-[20px]">
-        <div className="w-4 h-4 rounded-full bg-none border border-sub-text flex items-center justify-center">
-          <span className="text-sub-text text-[10px] font-bold">!</span>
-        </div>
-        <div className="body text-sub-text">
-          모든 멤버가 답변을 작성해야 답안이 공개돼요.
-          </div>
-        </div>
-      )}
-
-      {/* 가족 멤버 상태 리스트 */}
-      <div className="flex flex-col">
-        {questionData.myAnswered && (
-          <div
-          className={`
-            w-full
-            bg-bg
-            rounded-[4px]
-            py-[16px] px-5
-            flex flex-col gap-y-[8px]
-            border-b border-[#EAEAEA]
-          `}
-        >
-          {/* 멤버 이름 */}
-          <div className="flex flex-row items-center justify-between">
-            <div className="label-bold text-text">나</div>
-            <button  
-              onClick={handleToggleAnswer}
-              className="w-[16px] h-[16px] flex items-center justify-center focus:outline-none" 
-            >
-              <img 
-                src={down} 
-                alt="down" 
-                className={`w-[16px] h-[16px] transition-transform duration-300 ${
-                  isAnswerExpanded ? "rotate-180" : ""
-                }`}
-              />
-            </button>
-          </div>
-          <div 
-            className={`px-[12px] body text-text overflow-hidden transition-all duration-300 ease-in-out ${
-              !isAnswerExpanded ? "line-clamp-2" : ""
-            }`}
-            style={{
-              maxHeight: isAnswerExpanded ? "1000px" : "2.8em",
-            }}
-          >
-            {questionData.myAnswer}
-          </div>
-          </div>
-        )}
-        {familyMembers.map((member, index) => (
-          <div
-            key={index}
-            className={`
-              w-full
-              bg-bg
-              rounded-[4px]
-              py-[16px] px-5
-              flex flex-col gap-y-[8px]
-              ${index < familyMembers.length ? "border-b border-[#EAEAEA]" : ""}
-            `}
-          >
-            {/* 상태에 따른 표시 */}
-            {questionData.isAllAnswered && member.status === "answered" && (
-              <>
-                <div className="flex flex-row items-center justify-between">
-                  <div className="label-bold text-text">{member.name}</div>
-                  <button  
-                    onClick={() => handleToggleMemberAnswer(member.name)}
-                    className="w-[16px] h-[16px] flex items-center justify-center focus:outline-none" 
-                  >
-                    <img 
-                      src={down} 
-                      alt="down" 
-                      className={`w-[16px] h-[16px] transition-transform duration-300 ${
-                        expandedMembers[member.name] ? "rotate-180" : ""
-                      }`}
-                    />
-                  </button>
-                </div>
-                <div 
-                  className={`px-[12px] body text-text overflow-hidden transition-all duration-300 ease-in-out ${
-                    !expandedMembers[member.name] ? "line-clamp-2" : ""
-                  }`}
-                  style={{
-                    maxHeight: expandedMembers[member.name] ? "1000px" : "2.8em",
-                  }}
-                >
-                  {member.answer}
-                </div>
-              </>
-            )}
-
-            {!questionData.isAllAnswered && (
-              <>
-                {/* 멤버 이름 */}
-                <div className="label-bold text-text">{member.name}</div>
-              </>
-            )}
-
-            {!questionData.isAllAnswered && member.status === "locked" && (
-              <div className="flex flex-row items-center gap-[4px] pl-[12px]">
-                <img src={lock} alt="lock" className="w-[16px] h-[16px] items-center" />
-                <div className="body text-sub-text">
-                  아직 답변 공개 전이에요.
-                </div>
-              </div>
-            )}
-
-            {!questionData.isAllAnswered && member.status === "not_answered" && (
-              <div className="flex flex-row items-center justify-between px-[12px]">
-                <div className="body text-sub-text">
-                  아직 답변을 작성하지 않았어요.
-                </div>
-                <CommonButton
-                  label="마음 두드리기"
-                  bgColor="bg-sub-1"
-                  textColor={nudgedMembers[member.name] ? "text-[#ffffff] body" : "text-text body"}
-                  className="!w-fit !rounded-[8px]"
-                  padding="px-4 py-2.5"
-                  onClick={() => handleNudgeClick(member.name)}
-                  disabled={nudgedMembers[member.name] || false}
-                />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* 메시지 버튼 - isAllAnswered가 true일 때만 표시 */}
       {questionData.isAllAnswered && (
-        <button
-          onClick={handleMessageClick}
-          className="fixed bottom-[72px] right-[20px] w-12 h-12 !rounded-full bg-sub-1 flex items-center justify-center shadow-[2px_2px_4px_rgba(0,0,0,0.12)] z-10"
-        >
-          <img 
-            src={message} 
-            alt="message" 
-            className="w-6 h-6" 
-          />
-        </button>
+        <MessageButton onClick={handleMessageClick} />
       )}
 
-      {/* 댓글 바텀 시트 */}
-      {isCommentOpen && (
-        <>
-          {/* 배경 오버레이 */}
-          <div
-            className="fixed inset-0 bg-black/32 z-[998]"
-            onClick={() => {
-              handleCloseComment();
-              setOpenMenuId(null);
-            }}
-          />
-          
-          {/* 바텀 시트 */}
-          <div className="fixed bottom-0 left-0 right-0 w-full max-w-[420px] mx-auto bg-white rounded-t-[16px] shadow-[0_-4px_8px_rgba(0,0,0,0.08)] z-[999] flex flex-col max-h-[90vh]">
-            {/* 헤더 */}
-            <div className="flex flex-row items-center justify-center h-[57px] px-5 border-b border-[#EAEAEA]">
-              <div className="label-bold text-text">댓글</div>
-
-            </div>
-
-            {/* 댓글 리스트 */}
-            <div className="flex-1 overflow-y-auto pt-4">
-              <div className="flex flex-col gap-y-4">
-                {comments.map((comment, index) => {
-                  const commentEmoji = getEmojiById(comment.emoji);
-                  return (
-                    <div key={comment.id} className={`flex flex-row gap-3 pb-4 ${index < comments.length - 1 ? "border-b border-[#EAEAEA] pb-4" : ""}`}>
-                      
-                      <div className="flex-1 flex flex-col gap-y-[8px] pl-[12px]">
-                        <div className="flex flex-row items-center gap-[8px]">
-                          <div className="label-bold text-text">{comment.userName}</div>
-                          <div className="caption text-sub-text">{comment.timeAgo}</div>
-                        </div>
-                        <div className="flex flex-row items-center gap-2 pl-[12px] flex-wrap">
-                          {commentEmoji && (
-                            <img 
-                              src={commentEmoji.src} 
-                              alt={commentEmoji.label} 
-                              className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px]"
-                            />
-                          )}
-                          {comment.hasContent && comment.content && (
-                            <div className="body text-text">{comment.content}</div>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* 옵션 메뉴 */}
-                      <div className="relative flex-shrink-0 mr-5">
-                        <button 
-                          onClick={(e) => handleMoreClick(comment.id, e)}
-                          className="w-6 h-6 flex items-center justify-center focus:outline-none"
-                        >
-                          <img src={more} alt="more" className="w-6 h-6" />
-                        </button>
-                        
-                        {/* 팝업 메뉴 */}
-                        {openMenuId === comment.id && (
-                          <div 
-                            className="absolute right-0 top-8 bg-[#FFF6ED] rounded-[4px] flex flex-col shadow-[0_2px_4px_rgba(0,0,0,0.1)] z-10 min-w-[81px]"
-                            style={{ boxShadow: '0px 2px 4px rgba(0,0,0,0.1)' }}
-                          >
-                            <button
-                              onClick={() => handleEditComment(comment.id)}
-                              className="px-4 py-3 body text-text hover:bg-[#FFE5C7] rounded-t-[4px] text-left"
-                            >
-                              수정하기
-                            </button>
-                            <button
-                              onClick={() => handleDeleteComment(comment.id)}
-                              className="px-4 py-3 body text-text hover:bg-[#FFE5C7] rounded-b-[4px] text-left border-t border-[#EAEAEA]"
-                            >
-                              삭제하기
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* 댓글 입력 필드 */}
-            <div 
-              className="px-5 max-px-[20px] pt-[12px] border-t border-[#EAEAEA]"
-              style={{ boxShadow: '0px -4px 8px 0px #00000014' }}
-            >
-              <div className="flex flex-col">
-                {/* 입력 영역 */}
-                <div className="flex flex-row items-start gap-[10px] mb-[12px]">
-                  {/* 이모지 버튼 */}
-                  <button 
-                    onClick={handleEmojiToggle}
-                    className="w-[24px] h-[24px] flex items-center justify-center flex-shrink-0 my-auto focus:outline-none"
-                  >
-                    <img 
-                      src={isEmojiOpen ? emojiOn : emoji} 
-                      alt="emoji" 
-                      className="w-[24px] h-[24px]" 
-                    />
-                  </button>
-
-                  {/* 선택된 이모지 표시 영역 */}
-                  <div className="flex-1 flex flex-col gap-2">
-                    {selectedEmoji && (
-                      <div className="relative w-fit gap-x-[8px] flex flex-row items-start">
-                        <img 
-                          src={selectedEmoji.src} 
-                          alt={selectedEmoji.label} 
-                          className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px] items-center"
-                        />
-                        <button
-                          onClick={handleRemoveEmoji}
-                          className="w-[16px] h-[16px] flex items-center justify-center bg-white rounded-full text-sub-text"
-                        >
-                          <img src={X} alt="X" className="w-[16px] h-[16px]" />
-                        </button>
-                      </div>
-                    )}
-
-                    {/* 입력 필드 */}
-                    <textarea
-                      value={commentText}
-                      onChange={(e) => {
-                        setCommentText(e.target.value);
-                        // 높이 자동 조절
-                        e.target.style.height = "auto";
-                        e.target.style.height = `${e.target.scrollHeight}px`;
-                      }}
-                      placeholder={"따뜻한 공감과 이해의 댓글을 남겨주세요."}
-                      className="flex-1 max-h-[120px] py-[8px] rounded-[8px] body !line-height-1 text-text focus:outline-none resize-none overflow-y-auto"
-                      rows={1}
-                      onKeyDown={(e) => {
-                        // Shift + Enter: 줄바꿈, Enter만: 전송
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          handleSendComment();
-                        }
-                      }}
-                    />
-                  </div>
-
-                  {/* 전송 버튼 */}
-                  <div
-                    onClick={handleSendComment}
-                    className={`w-[24px] h-[24px] flex items-center justify-center bg-none flex-shrink-0 my-auto`}
-                  >
-                    <img src={send} alt="send" className="w-[24px] h-[24px]" />
-                  </div>
-                </div></div></div>
-                <div className="px-5 max-px-[20px] border-t border-[#EAEAEA] bg-outline">
-                  <div className="flex flex-col">
-
-                {/* 이모지 선택 그리드 */}
-                {isEmojiOpen && (
-                  <div className="flex flex-col gap-[16px] pt-[24px] z-[999]">
-                    <div className="label-bold text-text">공감 표현하기</div>
-                    <div className="grid grid-cols-3 gap-y-[20px] mb-[7.81vh] max-mb-[66px]">
-                      {emojiList.map((emoji) => (
-                        <button
-                          key={emoji.id}
-                          onClick={() => handleEmojiSelect(emoji)}
-                          className="flex items-center justify-center rounded-[8px]"
-                        >
-                          <img 
-                            src={emoji.src} 
-                            alt={emoji.label} 
-                            className="w-[20.35vw] h-[20.35vw] max-w-[80px] max-h-[80px] items-center"
-                          />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </>
-      )}
+      <CommentBottomSheet
+        isOpen={isCommentOpen}
+        isLoading={isCommentsLoading}
+        comments={comments}
+        commentText={commentText}
+        selectedEmoji={selectedEmoji}
+        isEmojiOpen={isEmojiOpen}
+        emojiList={EMOJI_LIST}
+        openMenuId={openMenuId}
+        editingCommentId={editingCommentId}
+        editingCommentText={editingCommentText}
+        editingSelectedEmoji={editingSelectedEmoji}
+        currentUserId={myUserId}
+        getEmojiById={getEmojiById}
+        onClose={() => {
+          handleCloseComment();
+          setOpenMenuId(null);
+          cancelEditComment();
+        }}
+        onCommentTextChange={setCommentText}
+        onEmojiToggle={handleEmojiToggle}
+        onEmojiSelect={handleEmojiSelect}
+        onRemoveEmoji={handleRemoveEmoji}
+        onSend={sendComment}
+        onMoreClick={handleMoreClick}
+        onEdit={handleEditComment}
+        onDelete={handleDeleteComment}
+        onEditingCommentTextChange={setEditingCommentText}
+        onEditingEmojiSelect={setEditingSelectedEmoji}
+        onEditingRemoveEmoji={() => setEditingSelectedEmoji(null)}
+        onSaveEdit={saveEditComment}
+        onCancelEdit={cancelEditComment}
+      />
 
       {/* 댓글 삭제 확인 모달 */}
       {deleteCommentId && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,13 +9,11 @@ const Home = () => {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
 
   const descDummy = "앞으로 마음 115개 더 모으면 가족 레벨이 올라요.";
-  const questionDummy =
-    "가족과 최근 나눴던 대화 중 <br/>가장 기억에 남는 순간은 언제인가요?";
 
   return (
     <div className="w-full flex flex-col">
       {/* gradient box */}
-      <GradientBox descDummy={descDummy} questionDummy={questionDummy} />
+      <GradientBox descDummy={descDummy} />
 
       {/* ans situation */}
       <AnswerSituation />

--- a/src/types/daily-question.ts
+++ b/src/types/daily-question.ts
@@ -1,0 +1,32 @@
+export interface FamilyMember {
+  userId: number;
+  name: string;
+  status: "locked" | "not_answered" | "answered";
+  answer?: string;
+}
+
+export interface Comment {
+  id: number;
+  userId: number;
+  userName: string;
+  timeAgo: string;
+  emoji?: string;
+  content: string;
+  hasContent: boolean;
+}
+
+export interface Emoji {
+  id: string;
+  label: string;
+  src: string;
+}
+
+export interface QuestionData {
+  dailyQuestionId: number;
+  questionNumber: number;
+  question: string;
+  isAllAnswered: boolean;
+  myAnswered: boolean;
+  myAnswer: string;
+}
+

--- a/src/utils/daily-question.ts
+++ b/src/utils/daily-question.ts
@@ -1,0 +1,109 @@
+import type { FamilyMember, Comment } from "../types/daily-question";
+import type { QuestionMember } from "../api/daily-question";
+import type { CommentItem } from "../api/comment";
+import type { Emoji } from "../types/daily-question";
+import { EMOJI_LIST } from "../constants/daily-question";
+
+// 시간 포맷팅 함수 (createdAt을 "지금", "2분 전" 등으로 변환)
+export const formatTimeAgo = (createdAt: string): string => {
+  const now = new Date();
+  const created = new Date(createdAt);
+  const diffMs = now.getTime() - created.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return "지금";
+  if (diffMins < 60) return `${diffMins}분 전`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}시간 전`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}일 전`;
+};
+
+// BOTH 타입 content 파싱 함수
+export const parseBothContent = (content: string): { emojiId: string; text: string } => {
+  const parts = content.split("|");
+  if (parts.length >= 2) {
+    return {
+      emojiId: parts[0].trim(),
+      text: parts.slice(1).join("|").trim(), // |가 텍스트에 포함될 수 있으므로
+    };
+  }
+  // 파싱 실패 시 전체를 텍스트로 처리
+  return {
+    emojiId: "",
+    text: content,
+  };
+};
+
+// 가족 멤버 데이터 변환
+export const transformFamilyMembers = (
+  members: QuestionMember[],
+  myUserId: number | null,
+  isAllAnswered: boolean
+): FamilyMember[] => {
+  return members
+    .filter((m) => m.userId !== myUserId) // 현재 사용자 제외
+    .map((m) => {
+      let status: "locked" | "not_answered" | "answered";
+      if (!isAllAnswered) {
+        if (!m.answered) {
+          status = "not_answered";
+        } else {
+          status = "locked"; // 다른 사람이 답변했지만 아직 공개 안됨
+        }
+      } else {
+        status = m.answered ? "answered" : "not_answered";
+      }
+
+      return {
+        userId: m.userId,
+        name: m.nickname,
+        status,
+        answer: isAllAnswered && m.answered ? m.answerContent : undefined,
+      };
+    });
+};
+
+// 댓글 변환 함수
+export const transformComment = (comment: CommentItem): Comment => {
+  const userName = comment.userNickname || "사용자";
+
+  // type에 따라 이모지와 텍스트 분리
+  let emojiId: string | undefined;
+  let contentText: string = "";
+  let hasContent: boolean = false;
+
+  if (comment.type === "EMOJI") {
+    // EMOJI 타입: content가 이모지 ID
+    emojiId = comment.content;
+    contentText = "";
+    hasContent = false;
+  } else if (comment.type === "BOTH") {
+    // BOTH 타입: "이모지ID|텍스트" 형식 파싱
+    const parsed = parseBothContent(comment.content);
+    emojiId = parsed.emojiId || undefined;
+    contentText = parsed.text;
+    hasContent = !!contentText;
+  } else {
+    // TEXT 타입
+    emojiId = undefined;
+    contentText = comment.content;
+    hasContent = !!contentText;
+  }
+
+  return {
+    id: comment.commentId,
+    userId: comment.userId,
+    userName: userName,
+    timeAgo: formatTimeAgo(comment.createdAt),
+    emoji: emojiId,
+    content: contentText,
+    hasContent: hasContent,
+  };
+};
+
+// 이모지 ID를 이미지로 매핑
+export const getEmojiById = (emojiId?: string): Emoji | null => {
+  if (!emojiId) return null;
+  return EMOJI_LIST.find((emoji) => emoji.id === emojiId) || null;
+};


### PR DESCRIPTION
# ISSUE-18

## Description

### 1. Axios 도입 및 API 클라이언트 설정
- `axios` 패키지 설치 및 중앙화된 API 클라이언트 구성
- Request/Response 인터셉터 구현 (토큰 자동 추가, 에러 처리)
- 모든 API 호출을 `fetch`에서 `axios`로 마이그레이션

### 2. 일일 질문 및 답변 API 연동
- **오늘의 질문 조회**: `GET /api/daily-questions/today`
  - Home 페이지 (`GradientBox`) 및 DailyQuestion 페이지에서 사용
- **답변 작성**: `POST /api/daily-questions/{dailyQuestionId}/answers/draft`
  - Answer 페이지에서 초안 답변 전송
- **최종 답변 저장**: `PATCH /api/daily-questions/{dailyQuestionId}/answers`
  - AIFeedback 페이지에서 최종 답변 제출

### 3. 댓글 기능 API 연동
- **댓글 조회**: `GET /api/comments?dailyQuestionId={dailyQuestionId}`
- **댓글 작성**: `POST /api/comments`
  - TEXT, EMOJI, BOTH 타입 지원
  - 이모지와 텍스트 조합 형식: `"emojiID|텍스트"`
- **댓글 수정**: `PUT /api/comments/{commentId}`
- **댓글 삭제**: `DELETE /api/comments/{commentId}`
  - CommonModal을 사용한 삭제 확인 다이얼로그

### 4. 컴포넌트 분리 및 리팩토링
- **DailyQuestion 페이지 리팩토링**
  - Custom Hooks: `useDailyQuestion`, `useComments`
  - Utils: `formatTimeAgo`, `parseBothContent`, `transformComment` 등
  - Constants: `EMOJI_LIST`
  - Types: 인터페이스 분리
- **컴포넌트 분리**:
  - `QuestionCard`, `InfoMessage`, `FamilyMemberList`, `MessageButton`
  - `CommentBottomSheet`, `CommentItem`, `CommentInput`, `EmojiSelector`

### 5. 기능 개선
- 본인 댓글에만 수정/삭제 옵션 메뉴 표시
- 댓글 수정 시 인라인 편집 모드
- 댓글 삭제 시 확인 모달 표시

**주의**: `axios` 패키지가 새로 추가되었으므로 반드시 설치가 필요합니다.

```bash
# 의존성 설치
pnpm install
```

### 파일 구조

```
src/
├── api/
│   ├── axios.ts          # Axios 인스턴스 및 인터셉터
│   ├── daily-question.ts # 일일 질문 관련 API
│   ├── comment.ts        # 댓글 관련 API
│   └── ...
├── hooks/
│   ├── useDailyQuestion.ts # 질문 데이터 로딩
│   └── useComments.ts       # 댓글 로직
├── utils/
│   └── daily-question.ts   # 유틸 함수들
├── types/
│   └── daily-question.ts   # 타입 정의
├── constants/
│   └── daily-question.ts   # 상수 정의
└── components/
    └── daily-question/     # 분리된 컴포넌트들
```



## Issue Link

- closed #18 
